### PR TITLE
use this instead of facet which is not yet defined when deferred

### DIFF
--- a/facet.js
+++ b/facet.js
@@ -127,6 +127,7 @@ const facet = new function() {
    * @param {ParentNode} root The parent element to discover inside.
    */
   this.discoverDeclarativeComponents = function discoverDeclarativeComponents(root) {
+    let facet = this;
     let mixinSelector = `template[${facet.config.namespace}mixin]:not([defined])`
     let cmpntSelector = `template[${facet.config.namespace}component]:not([defined])`
 


### PR DESCRIPTION
`facet` seems to be undefined while autodiscovering components if Facet is included with `defer`:
```
<script defer src="facet-0.1.2a.min.js"></script>
```
This PR uses `this` instead.
Please feel free to reject or fix in an alternative way if you can think of a better approach.