### PR TITLE
implement slots when used without shadow DOM

### DIFF
--- a/facet.js
+++ b/facet.js
@@ -92,6 +92,34 @@ const facet = new function() {
           el.removeAttribute('inherit')
         }
 
+        // Implement slotting manually when no shadow DOM in use
+        if (shadowMode === 'none') {
+          const root = this.#root
+          // named slots
+          content.querySelectorAll('slot[name]').forEach(slot => {
+              const slotName = slot.getAttribute('name')
+              var defaultOverwritten = false
+              root.querySelectorAll(`[slot="${slotName}"]`).forEach(slotContent => {
+                if (!defaultOverwritten) {
+                  defaultOverwritten = true
+                  slot.innerHTML = ''
+                }
+                slot.appendChild(slotContent)
+              })
+          })
+          // unnamed slots
+          content.querySelectorAll('slot:not([name])').forEach(slot => {
+            var defaultOverwritten = false
+            root.querySelectorAll(':scope > *:not([slot])').forEach(slotContent => {
+              if (!defaultOverwritten) {
+                defaultOverwritten = true
+                slot.innerHTML = ''
+              }
+              slot.appendChild(slotContent)
+            })
+          })
+        }
+
         if(formAssoc) this.value = this.getAttribute('value')
         this.#root.append(content)
         this.#event('connect')


### PR DESCRIPTION
The HTML standard only specifies slot functionality to work with a shadow DOM. For many (if not most) use cases however, shadow DOM would cause problems regarding style isolation.

This PR adds an implementation to explicitly mimic slot functionality when shadow DOM is not in use. Since slots _shouldn't_ work at all, I'd say this functionality cannot do any harm.

I'm not familiar with any details or edge cases, so please feel free to modify this PR, or let me know if there's anything I could do to help.

Really useful and simple library, thank you!